### PR TITLE
Hasta ahora los botones por tipo ya funcionan

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,8 +10,81 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css" />
-<<<<<<< HEAD
   </head>
+
+<body>
+    <!-- Navbar (sit on top)-->
+
+    <ul class="topnav">
+        <li><a class="active" href="#PaginaInicio" id="return-button">Inicio</a></li>
+        <li><a href="#instructions" id="help-button">Instrucciones</a></li>
+        <li><a href="#dataPokemon" id="show-button">Pokedex!</a></li>
+
+    </ul>
+
+    <section id="PaginaInicio" class="display_block">
+
+    </section>
+
+    <section class="hide" id="instructions">
+        <div class="instructions-text ">
+            <input type="button" name="close" value="X" id="close">
+            <h2>Instrucciones</h2>
+            <p>Esta es una página donde puedes visualizar los 151 Pokémones de la región Kento.</p>
+            </br>
+            <p>Utilizarlo es muy sencillo, para ingresar solo necesitas dar click en "Pokedex " y ahí podras ver todos los Pokémones, así como filtrar por tipo, evolución y por nombre de forma ascedente o descendente.</p>
+        </div>
+    </section>
+
+
+    <!-- pokedex-->
+    <section id="tipos-Pokemon" class="hide">
+
+           <h4>Busca por tipo de Pokémon:</h4>
+           <button id="Normal" class="buttonType">Normal</button>
+           <button id="Fire" class="buttonType">Fuego(Fire)</button>
+           <button id="Grass" class="buttonType">Hierba(Grass)</button>
+           <button id="Poison" class="buttonType">Veneno(Poison</button>
+           <button id="Ice" class="buttonType">Hielo(Ice)</button>
+           <button id="Water" class="buttonType">Agua(Water)</button>
+           <button id="Flying" class="buttonType">Volador(Flying)</button>
+           <button id="Psychic" class="buttonType">Psíquico(Psychic)</button>
+           <button id="Ground" class="buttonType">Tierra(Ground)</button>
+           <button id="Ghost" class="buttonType">Fantasma(Ghost)</button>
+           <button id="Bug" class="buttonType">Insecto(Bug)</button>
+
+        
+      </section>
+
+      <section id="tipos" class="hide">
+          <ul class="topnav">
+ 
+      
+          </ul>
+<h4>Pokémon tipo:</h4>
+      </section>
+
+    <section id="dataPokemon" class="container Pokedex hide">
+
+ 
+    </section>
+
+    <section id="tipo-hierba" class="hide">
+      <h3>Aquí va la sección pokémon tipo hierba (grass)</h3>  
+      <div id="Grass-pokemon" class="card-Grass"></div>
+    </section>
+
+
+    <div id="root "></div>
+   
+    <script src="./data/pokemon/pokemon.js "></script>
+
+    <script src="main.js "></script>
+    <script src="data.js "></script>
+
+</body>
+
+</html>
 
   <!--
   <body>
@@ -101,88 +174,3 @@
       <div id="fight-pokemon" class="card"></div>
     </section> 
 -->
-    <!-- <script src="./data/injuries/injuries.js"></script> -->
-    <script src="./data/pokemon/pokemon.js"></script>
-    <!-- <script src="./data/steam/steam.js"></script> -->
-    <!-- <script src="./data/worldbank/worldbank.js"></script> -->
-    <!-- <script src="./data/lol/lol.js"></script> -->
-    
-    
-    <script src="main.js"></script>
-    <script src="data.js"></script>
-  </body>
-</html>
-=======
-</head>
-
-<body>
-    <!-- Navbar (sit on top)-->
-
-    <ul class="topnav">
-        <li><a class="active" href="#PaginaInicio" id="return-button">Inicio</a></li>
-        <li><a href="#instructions" id="help-button">Instrucciones</a></li>
-        <li><a href="#dataPokemon" id="show-button">Pokedex!</a></li>
-
-    </ul>
-
-    <section id="PaginaInicio" class="display_block">
-
-
-
-    </section>
-
-    <section class="hide" id="instructions">
-        <div class="instructions-text ">
-            <input type="button" name="close" value="X" id="close">
-            <h2>Instrucciones</h2>
-            <p>Esta es una página donde puedes visualizar los 151 Pokémones de la región Kento.</p>
-            </br>
-            <p>Utilizarlo es muy sencillo, para ingresar solo necesitas dar click en "Pokedex " y ahí podras ver todos los Pokémones, así como filtrar por tipo, evolución y por nombre de forma ascedente o descendente.</p>
-        </div>
-    </section>
-
-
-    <!-- pokedex-->
-
-    <section id="dataPokemon" class="container Pokedex hide">
-
-        <nav id="colorNav">
-            <ul>
-                <li class="green">
-                    <a href="#" class="icon-home"></a>
-                    <ul>
-                        <li><a href="#">Dropdown item 1</a></li>
-                        <li><a href="#">Dropdown item 2</a></li>
-                        <!-- More dropdown options -->
-                    </ul>
-                </li>
-
-                <!-- More menu items -->
-
-            </ul>
-        </nav>
-        <ul class="topnav">
-            <li><a class="active" href="#PaginaInicio" id="return-button">Inicio</a></li>
-            <li><a href="#instructions" id="help-button">Instrucciones</a></li>
-            <li><a href="#dataPokemon" id="show-button">Pokedex!</a></li>
-
-        </ul>
-
-
-    </section>
-
-
-
-    <div id="root "></div>
-    <!-- <script src="./data/injuries/injuries.js "></script> -->
-    <script src="./data/pokemon/pokemon.js "></script>
-    <!-- <script src="./data/steam/steam.js "></script> -->
-    <!-- <script src="./data/worldbank/worldbank.js "></script> -->
-    <!-- <script src="./data/lol/lol.js "></script> -->
-    <script src="main.js "></script>
-    <script src="data.js "></script>
-
-</body>
-
-</html>
->>>>>>> origin/master

--- a/src/main.js
+++ b/src/main.js
@@ -1,37 +1,88 @@
-<<<<<<< HEAD
-//Funciones generales para mostrar y ocultar secciones -esto evita abrir varios HTML's//
-const ocultarSeccion=(id)=>{
-    document.getElementById(id).classList.add('oculto')
-    }
-const mostrarSeccion=(id)=>{
-    document.getElementById(id).classList.remove('oculto')
-    }
+//Working with help button-instructions
+const helpButton = document.getElementById('help-button');
+const closeButton = document.getElementById('close');
+const returnButton = document.getElementById('return-button');
 
-const ocultarBoton=(id)=>{
-    document.getElementById(id).classList.add('boton')
+
+//Function that hide section with id
+const hideSection = (id) => {
+        document.getElementById(id).classList.add('hide');
     }
-    
+    //Function that show section with id
+const showSection = (id) => {
+    document.getElementById(id).classList.remove('hide');
+}
+
+
+//Functionability for help button and close button
+const showInstructions = () => showSection('instructions');
+const closeInstructions = () => hideSection('instructions');
+
+helpButton.addEventListener("click", showInstructions);
+closeButton.addEventListener("click", closeInstructions)
+
+//BotonInicio
+
+const goBack = document.getElementById('return-button');
+
+const goback = () => { 
+    hideSection('dataPokemon');
+    hideSection('tipos-Pokemon')
+    hideSection('tipos')
+    showSection('PaginaInicio');
+}
+
+goBack.addEventListener("click", goback);
+
+
+
+//Seccion Pokemones
+const AllPokemon = document.getElementById('show-button');
+
+const openPokedex = () => {
+    hideSection('PaginaInicio');
+    hideSection('tipos');
+    showSection('dataPokemon');
+    showSection('tipos-Pokemon');
+}
+
+AllPokemon.addEventListener("click", openPokedex);    
 
 
 
 // Función para mostrar la data en html //
-const baseData=POKEMON.pokemon;
-const card=document.getElementById('pokemon-card');
-const cardData=()=>{
-    let str=''
-      baseData.forEach(element => {
-        console.log(element)
-        str += `<div class=card">
-          <p>${element.num}</p>
-            <img src="${element.img}"></img>
-            <p>${element.name}</p>
-            <p>${element.type}</p>
-            </div>`
-        });
+//Data
 
-card.innerHTML=str
+const baseData = POKEMON.pokemon;
+const card = document.getElementById("dataPokemon");
+
+const cardData = () => {
+    let str = ''
+    baseData.forEach(element => {
+        str +=
+            `<div class="Pokedex">
+        <div class= "card">
+        
+        <p>Num. ${element.num}</p>
+       
+        <div class="img">
+        <img src="${element.img}"></img>
+        </div>
+        
+        <div class="info">
+        <p>${element.name}</p>
+        
+         <p>${element.type}</p>
+        </div>
+        </div>
+        </div>`
+
+    });
+
+    card.innerHTML = str
 };
 cardData()
+
 
 ///Para que me aparezcan los tipos de pokemon existentes en la data ///
 //let tipoPok=[]
@@ -54,37 +105,62 @@ const orderName=namePok.sort();
 
 // sección para segundo filtro por tipo de pokémon //
 
-    //Ocultar y mostrar sección//
-const pokType=document.getElementById('tipo-boton');
-const secType=()=>{
-    alert('prueba');
-    ocultarSeccion('principal');
-    mostrarSeccion('tipo-pokemon');
-    
-    
-}
-pokType.addEventListener('click',secType);
+
     /////////////////////////////////
+    const pokemonType = document.getElementById('tipos-Pokemon');
+    const openType = () => {
+        hideSection('tipos-Pokemon');
+        hideSection('dataPokemon')
+        showSection('tipos');
+    }
+    
+  pokemonType.addEventListener("click", openType);   
+
+
+
+const button = document.getElementsByClassName('buttonType')
+//console.log(button)
+
+const targetPok=(event)=>{
+console.log(event.target.id);
+//event.target.id
+}
+
+for(let i = 0; i < button.length ; i++){
+    button[i].addEventListener('click' , targetPok);
+ 
+
+  }
+  const typePokemon=baseData.filter(function(el){
+    return el.type.find(targetPok);
+  });
+cardData(targetPok)
+
+ 
+
+
+
+
     //Filtro para que aparezcan por tipo hierba//
-const grassPok=baseData.filter(function(el){ //el es el equivalente del objeto dentro del arreglo, este es el que irá recorriendo//
-        return el.type.find(tipo=>tipo==='Ice');
+//const grassPok=baseData.filter(function(el){ //el es el equivalente del objeto dentro del arreglo, este es el que irá recorriendo//
+  //      return el.type.find(tipo=>tipo==='Grass');
         
-});
-        console.log(grassPok);
-const grassType=document.getElementById('Grass-pokemon');
-const cardGrass=()=>{
-    let grassStr=''
-         grassPok.forEach(element =>{
-            grassStr += `<div class=card>
-            <p>${element.num}</p>
-            <img src="${element.img}"></img>
-            <p>${element.name}</p>
-            <p>${element.type}</p>
-            </div>`
-});
-grassType.innerHTML=grassStr
-};
-cardGrass()
+//});
+  //      console.log(grassPok);
+//const grassType=document.getElementById('Grass-pokemon');
+//const cardGrass=()=>{
+  //  let grassStr=''
+    //     grassPok.forEach(element =>{
+      //      grassStr += `<div class=card>
+        //    <p>${element.num}</p>
+          //  <img src="${element.img}"></img>
+           // <p>${element.name}</p>
+            //<p>${element.type}</p>
+            //</div>`
+//});
+//grassType.innerHTML=grassStr
+//};
+//cardGrass()
 
     //Filtro para que aparezca por tipo veneno//
 const poisPok=baseData.filter(function(el){ //el es el equivalente del objeto dentro del arreglo, este es el que irá recorriendo//
@@ -296,98 +372,3 @@ const cardFight=()=>{
 fightType.innerHTML=fightStr;
 };
 cardFight() 
-
-
-const buton = document.getElementsByClassName('buttons')
-console.log(buton)
-
-
-for(let i = 0; i < buton.length ; i++ ){
-    buton[i].addEventListener('click' , () =>{
-            console.log(event.target.id)
-        })
-}
-
-=======
-//Working with help button-instructions
-const helpButton = document.getElementById('help-button');
-const closeButton = document.getElementById('close');
-const returnButton = document.getElementById('return-button');
-
-
-//Function that hide section with id
-const hideSection = (id) => {
-        document.getElementById(id).classList.add('hide');
-    }
-    //Function that show section with id
-const showSection = (id) => {
-    document.getElementById(id).classList.remove('hide');
-}
-
-
-//Functionability for help button and close button
-const showInstructions = () => showSection('instructions');
-const closeInstructions = () => hideSection('instructions');
-
-helpButton.addEventListener("click", showInstructions);
-closeButton.addEventListener("click", closeInstructions)
-
-//BotonRegresar
-
-const goBack = document.getElementById('return-button');
-
-const goback = () => {
-    hideSection('dataPokemon');
-    showSection('PaginaInicio');
-}
-
-goBack.addEventListener("click", goback);
-
-
-
-//Seccion Pokemones
-const AllPokemon = document.getElementById('show-button');
-
-const openPokedex = () => {
-    hideSection('PaginaInicio');
-    showSection('dataPokemon');
-}
-
-AllPokemon.addEventListener("click", openPokedex);
-
-
-
-//Data
-
-const baseData = POKEMON.pokemon;
-const card = document.getElementById("dataPokemon");
-
-const cardData = () => {
-    let str = ''
-    baseData.forEach(element => {
-        str +=
-            `<div class="Pokedex">
-        <div class= "card">
-        
-        <p>Num. ${element.num}</p>
-       
-        <div class="img">
-        <img src="${element.img}"></img>
-        </div>
-        
-        <div class="info">
-        <p>${element.name}</p>
-        
-         <p>${element.type}</p>
-        </div>
-        </div>
-        </div>`
-
-    });
-
-    card.innerHTML = str
-};
-cardData()
-
-//Filtro1-Por tipo
->>>>>>> origin/master


### PR DESCRIPTION
Los botones para cada tipo de Pokémon, al momento de hacerle click, me llevan a una nueva página donde en teoría deben aparecer las tarjetas según el tipo. 
La sección del navegador, ya se oculta en donde debe de ser así, que es al momento de darle click a inicio y si están en la página de tipo y seleccionan nuevamente pokédex. 